### PR TITLE
fix: changed “logins_count” attribute type from long to int

### DIFF
--- a/src/main/java/jp/openstandia/connector/auth0/Auth0UserHandler.java
+++ b/src/main/java/jp/openstandia/connector/auth0/Auth0UserHandler.java
@@ -274,7 +274,7 @@ public class Auth0UserHandler {
                 .setUpdateable(false)
                 .build());
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_LOGINS_COUNT)
-                .setType(Long.class)
+                .setType(Integer.class)
                 .setCreateable(false)
                 .setUpdateable(false)
                 .build());


### PR DESCRIPTION
Since "logins_count" is Integer type in Auth0 SDK, the schema definition of the connector should also be int.